### PR TITLE
    Deleted the addition of an extra space in the EXTRACT function wh…

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ extract = (filePath) => {
       for (let i = 0; i < components.length; i++) {
         let tags = components[i].split('>');
         let content = tags[1].replace(/<.*$/, '');
-        body += content + ' ';
+        body += content;
       }
       resolve(body);
     });


### PR DESCRIPTION
…en updating the content variable of docx documents. The extra space is not needed and can cause unwanted spaces to appear when extracting text from some docx files. Since spaces between word are already included within the <w:t> tags, removing this does not adversely affect the process of text extraction and avoids extra insertion of spaces in the pulled text.