### PR TITLE
add error handling on stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const StreamZip = require('node-stream-zip');
 const XLSX = require('xlsx');
 const pdf = require('pdf-parse');
-let WordExtractor = require('word-extractor');
+var WordExtractor = require('word-extractor');
 
 // extract text from office books as doc and docx
 extract = (filePath) => {
@@ -19,6 +19,8 @@ extract = (filePath) => {
         body += content;
       }
       resolve(body);
+    }).catch((err) => {
+      reject(err);
     });
   });
 };
@@ -47,6 +49,9 @@ open = (filePath) => {
         });
       });
     });
+    zip.on('error', (err) => {
+      reject(err);
+    });
   });
 };
 
@@ -69,11 +74,15 @@ exports.getText = async (filePath) => {
   switch (fileExtension) {
     // read pdf
     case '.pdf':
-      fileContent = (await pdf(data)).text;
+      fileContent = await (await pdf(data)).text;
       break;
 
     // read docs
+
     case '.docx':
+      fileContent = await extract(filePath);
+      break;
+
     case '.doc':
       var extractor = new WordExtractor();
       var extracted = await extractor.extract(filePath);
@@ -97,10 +106,9 @@ exports.getText = async (filePath) => {
       fileContent = JSON.stringify(result);
       break;
 
-    // read text, csv and json
+    // read text and csv
     case '.txt':
     case '.csv':
-    case '.json':
       fileContent = data.toString();
       break;
 
@@ -108,5 +116,7 @@ exports.getText = async (filePath) => {
     default:
       throw new Error('unknown extension found!');
   }
+  // console.log(`This is file content ==> ${fileContent}`);
   return fileContent;
 };
+


### PR DESCRIPTION
![изображение](https://github.com/user-attachments/assets/a3ff1ef8-14dc-4948-a793-7eaf52b13b56)
if any-text try to read broken file there is no error-handling and app crash every time, almost in try-catch construction
i added error handling so apps didnt crash anymore if file is broken and just rejects promise
![изображение](https://github.com/user-attachments/assets/ed4fbabf-0aff-465e-a127-f55d99eb2204)

